### PR TITLE
feat: use Scarf Gateway for DevLake helm charts downloads

### DIFF
--- a/charts/devlake/values.yaml
+++ b/charts/devlake/values.yaml
@@ -124,7 +124,7 @@ mysql:
 grafana:
   # image for grafana
   image:
-    repository: apache/devlake-dashboard
+    repository: devlake.docker.scarf.sh/apache/devlake-dashboard
     pullPolicy: Always
 
   # If true, the default Nginx configuration will support a permanent redirect
@@ -186,7 +186,7 @@ awsCognitoAuth:
 
 lake:
   image:
-    repository: apache/devlake
+    repository: devlake.docker.scarf.sh/apache/devlake
     pullPolicy: Always
     # defaults to imageTag; if set, lake.image.tag will override imageTag
     # tag:
@@ -225,7 +225,7 @@ lake:
 
 ui:
   image:
-    repository: apache/devlake-config-ui
+    repository: devlake.docker.scarf.sh/apache/devlake-config-ui
     pullPolicy: Always
     # defaults to imageTag; if set, lake.image.tag will override imageTag
     # tag:


### PR DESCRIPTION
This PR updates the DevLake helm charts configuration to fetch DevLake containers via a Scarf endpoint, so that DevLake maintainers can collect basic de-identified download and adoption metrics. It does not affect where the containers are being hosted, as Scarf is only redirecting traffic back to Docker Hub. 

This change was suggested by DevLake maintainers in direct discussions. We have a separate PR up for the DevLake Docker Compose setup. 